### PR TITLE
 Update poller registration after each poll

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release fixes #15, an issue introduced by 595f189 causing pollers to
+perform slower because the event registration was not always reflecting the
+connection state.

--- a/gearman/util.py
+++ b/gearman/util.py
@@ -64,7 +64,7 @@ def select(rlist, wlist, xlist, timeout=None):
         rd_list, wr_list, ex_list = select_lib.select(*select_args)
     except select_lib.error as exc:
         # Ignore interrupted system call, reraise anything else
-        if exc[0] != errno.EINTR:
+        if exc.errno != errno.EINTR:
             raise
 
     return rd_list, wr_list, ex_list

--- a/tools/hypothesistooling.py
+++ b/tools/hypothesistooling.py
@@ -151,8 +151,8 @@ def modified_files():
         ['git', 'diff', '--name-only']
     ]:
         diff_output = subprocess.check_output(command).decode('ascii')
-        for l in diff_output.split('\n'):
-            filepath = l.strip()
+        for line in diff_output.split('\n'):
+            filepath = line.strip()
             if filepath:
                 assert os.path.exists(filepath)
                 files.add(filepath)


### PR DESCRIPTION
The eventmask used when registering with epoll needs to be updated to
reflect both conn.readable() and conn.writable(). Not doing this may
cause `epoll.wait` to return immediately.

Fixes https://github.com/wellcomecollection/python-gearman/issues/15 - unless there are more issues I haven't seen yet.