### PR TITLE
Fix issue for python3.9+

### DIFF
--- a/gearman/connection.py
+++ b/gearman/connection.py
@@ -198,7 +198,7 @@ class GearmanConnection(object):
                 recv_buffer += self.gearman_socket.recv(remaining)
                 remaining = self.gearman_socket.pending()
 
-        self._incoming_buffer.fromstring(recv_buffer)
+        self._incoming_buffer.frombytes(recv_buffer)
         return len(self._incoming_buffer)
 
     def _unpack_command(self, given_buffer):


### PR DESCRIPTION
## What does this change?

`fromstring` method is removed since python 3.9. There was a note in previous versions to switch from `fromstring` into 
`frombytes`. here is the links

https://docs.python.org/3.8/library/array.html#array.array.frombytes
https://docs.python.org/3.8/library/array.html#array.array.fromstring

## How to test

Test it in any py3.9 environment. clearly it is broken

## How can we measure success?

N/A

## Have we considered potential risks?

`frombytes` is available since python 3.2 but not older versions. so if someone still uses something older than 3.2, `frombytes` won't work for him

